### PR TITLE
Use configDropins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM websphere-liberty
-ADD server.xml /opt/ibm/wlp/usr/servers/defaultServer/server.xml
-ENV LICENSE=accept
+FROM websphere-liberty:webProfile7
+COPY remote.xml /config/configDropins/overrides/remote.xml
 
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This guide will help you:
 git clone <THIS REPO URL>
 cd LibertyIBMContainers
 
-# If you want to change the username and password for remote admin (recommended), you can edit the server.xml
+# If you want to change the username and password for remote admin (recommended), you can edit remote.xml
 
 # Prereq: Install cf, cf ic extension and log in to cf.
 # Build docker image on IBM Containers using the Dockerfile in this folder.
@@ -45,7 +45,7 @@ In the Servers view of Eclipse, right-click to create a new Liberty server. Sele
 
 ![alt tag](https://raw.githubusercontent.com/rvennam/LibertyIBMContainers/master/screenshots/NewServerCredentials.png)
 
-Fill in the credentials. The default User is adminUser, Password is adminPassword and the Port 9443. These were defined in the server.xml in the previous section.
+Fill in the credentials. The default User is adminUser, Password is adminPassword and the Port 9443. These were defined in the server configuration in the previous section.
 
 3) Click Verify and Finish!
 

--- a/remote.xml
+++ b/remote.xml
@@ -3,7 +3,6 @@
     <!-- NOTE: This file is for reference only. -->
 
     <featureManager>
-        <feature>webProfile-7.0</feature>
         <feature>restConnector-1.0</feature>
     </featureManager>
 
@@ -11,22 +10,13 @@
     <!-- CHANGE PASSWORD HERE.  PASSWORD IS CURRENTLY SET TO adminPassword -->
     <quickStartSecurity userName="adminUser" userPassword="{xor}PjsyNjEPPiwsKDAtOw=="/>
 
-    <!-- TODO: Set the SSL keystore password -->
-    <keyStore id="defaultKeyStore" password="{xor}NDomLCswLToPPiwsKDAtOw=="/>
-
-	<!-- TODO: Set HTTP Endpoint attributes -->
-    <httpEndpoint id="defaultHttpEndpoint"
-                  host="*"
-                  httpPort="9080"
-                  httpsPort="9443"/>
-
      <!-- TODO: Use readDir and writeDir to specify directories that remote
           clients are allowed to have read and write access. There can be
           multiple readDir and writeDir elements. Replace writePath and readPath
           variables with your choice of locations or remove them if not needed. -->
      <remoteFileAccess>
-         <writeDir>/opt/ibm</writeDir>
-         <readDir>/opt/ibm</readDir>
+	     <writeDir>/opt/ibm/wlp</writeDir>
+	     <readDir>/opt/ibm/wlp</readDir>
      </remoteFileAccess>
 
 </server>


### PR DESCRIPTION
A few minor tweaks:
- Use the websphere-liberty:webProfile7 image
- License acceptance no longer required
- Use the default server.xml and extend with configDropins

I haven't managed to test this as, for me, WDT thinks that the server is stopped even though it can read the config from it!
